### PR TITLE
Fix clang error and warnings

### DIFF
--- a/src/dsp/src/gkick_log.h
+++ b/src/dsp/src/gkick_log.h
@@ -34,7 +34,7 @@ gkick_log_msg(const char *message, ...);
 #define GKICK_LIB_LOG_LEVEL_DEBUG
 #ifdef GKICK_LIB_LOG_FUNCTION
 #define gkick_log_trace(message, ...) \
-  gkick_log_msg("[TRACE][%s] "message, __func__, ##__VA_ARGS__)
+  gkick_log_msg("[TRACE][%s] " message, __func__, ##__VA_ARGS__)
 #else
 #define gkick_log_trace(message, ...) gkick_log_msg("[TRACE] " message, ##__VA_ARGS__)
 #endif
@@ -46,7 +46,7 @@ gkick_log_msg(const char *message, ...);
 #define GKICK_LIB_LOG_LEVEL_INFO
 #ifdef GKICK_LIB_LOG_FUNCTION
 #define gkick_log_debug(message, ...) \
-  gkick_log_msg("[DEBUG][%s] "message, __func__, ##__VA_ARGS__)
+  gkick_log_msg("[DEBUG][%s] " message, __func__, ##__VA_ARGS__)
 #else
 #define gkick_log_debug(message, ...) gkick_log_msg("[DEBUG] " message, ##__VA_ARGS__)
   #endif
@@ -58,7 +58,7 @@ gkick_log_msg(const char *message, ...);
 #define GKICK_LIB_LOG_LEVEL_WARNING
 #ifdef GKICK_LIB_LOG_FUNCTION
 #define gkick_log_info(message, ...) \
-  gkick_log_msg("[INFO][%s] "message, __func__, ##__VA_ARGS__)
+  gkick_log_msg("[INFO][%s] " message, __func__, ##__VA_ARGS__)
 #else
 #define gkick_log_info(message, ...) gkick_log_msg("[INFO] " message, ##__VA_ARGS__)
   #endif
@@ -70,7 +70,7 @@ gkick_log_msg(const char *message, ...);
   #define GKICK_LIB_LOG_LEVEL_ERROR
 #ifdef GKICK_LIB_LOG_FUNCTION
 #define gkick_log_warning(message, ...) \
-  gkick_log_msg("[WARNING][%s] "message, __func__, ##__VA_ARGS__)
+  gkick_log_msg("[WARNING][%s] " message, __func__, ##__VA_ARGS__)
 #else
 #define gkick_log_warning(message, ...) gkick_log_msg("[WARNING] " message, ##__VA_ARGS__)
 #endif
@@ -82,7 +82,7 @@ gkick_log_msg(const char *message, ...);
 #define GKICK_LIB_LOG_LEVEL_CRITICAL
 #ifdef GKICK_LIB_LOG_FUNCTION
 #define gkick_log_error(message, ...) \
-  gkick_log_msg("[ERROR][%s] "message, __func__, ##__VA_ARGS__)
+  gkick_log_msg("[ERROR][%s] " message, __func__, ##__VA_ARGS__)
 #else
 #define gkick_log_error(message, ...) gkick_log_msg("[ERROR] " message, ##__VA_ARGS__)
 #endif

--- a/src/dsp/src/ring_buffer.c
+++ b/src/dsp/src/ring_buffer.c
@@ -108,7 +108,7 @@ ring_buffer_get_size(struct ring_buffer *ring)
         return ring->size;
 }
 
-size_t
+void
 ring_buffer_resize(struct ring_buffer *ring,
                    size_t size)
 {

--- a/src/dsp/src/ring_buffer.h
+++ b/src/dsp/src/ring_buffer.h
@@ -77,7 +77,7 @@ ring_buffer_next(struct ring_buffer *ring,
 size_t
 ring_buffer_get_size(struct ring_buffer *ring);
 
-size_t
+void
 ring_buffer_resize(struct ring_buffer *ring,
                    size_t size);
 

--- a/src/dsp/src/synthesizer.c
+++ b/src/dsp/src/synthesizer.c
@@ -1066,10 +1066,8 @@ synth_kick_env_set_apply_type(struct gkick_synth *synth,
 			      enum gkick_envelope_apply_type apply_type)
 {
         gkick_synth_lock(synth);
-        switch (env_type) {
-	case GEONKICK_FILTER_CUTOFF_ENVELOPE:
+        if (env_type == GEONKICK_FILTER_CUTOFF_ENVELOPE) {
 		gkick_envelope_set_apply_type(synth->filter->cutoff_env, apply_type);
-		break;
 	}
 
         if (env_type == GEONKICK_AMPLITUDE_ENVELOPE
@@ -1090,10 +1088,8 @@ synth_kick_env_get_apply_type(struct gkick_synth *synth,
 			      enum gkick_envelope_apply_type *apply_type)
 {
 	gkick_synth_lock(synth);
-        switch (env_type) {
-	case GEONKICK_FILTER_CUTOFF_ENVELOPE:
+        if (env_type == GEONKICK_FILTER_CUTOFF_ENVELOPE) {
 		*apply_type = gkick_envelope_get_apply_type(synth->filter->cutoff_env);
-		break;
 	}
         gkick_synth_unlock(synth);
         return GEONKICK_OK;	

--- a/src/oscillator_envelope.h
+++ b/src/oscillator_envelope.h
@@ -33,7 +33,7 @@ class OscillatorEnvelope: public Envelope
  public:
 
   OscillatorEnvelope(Oscillator* osc, const RkRect &area);
-  double envelopeLength(void) const;
+  double envelopeLength(void) const override;
   Oscillator* getOscillator() const;
 
  protected:

--- a/src/redkite/include/RkEventQueue.h
+++ b/src/redkite/include/RkEventQueue.h
@@ -30,7 +30,7 @@
 
 class RkEvent;
 class RkTimer;
-class RkWindowId;
+struct RkWindowId;
 class RkWidget;
 
 class RK_EXPORT RkEventQueue {

--- a/src/redkite/include/impl/RkCairoGraphicsBackend.h
+++ b/src/redkite/include/impl/RkCairoGraphicsBackend.h
@@ -58,7 +58,6 @@ class RkCairoGraphicsBackend {
         cairo_t* context() const;
 
  private:
-        RkCanvas *canvas;
         cairo_t* cairoContext;
 };
 

--- a/src/redkite/src/RkCairoGraphicsBackend.cpp
+++ b/src/redkite/src/RkCairoGraphicsBackend.cpp
@@ -34,8 +34,7 @@
 #endif
 
 RkCairoGraphicsBackend::RkCairoGraphicsBackend(RkCanvas *canvas)
-        : canvas {canvas}
-        , cairoContext{nullptr}
+        : cairoContext{nullptr}
 {
         auto canvaseInfo = canvas->getCanvasInfo();
         if (!canvaseInfo) {


### PR DESCRIPTION
While working on #34 i tried to build the plugin with clang but discovered `-Wreserved-user-defined-literal` error and several other warnings repeated for each inclusion of problematic file. So, here are the fixes. Most changes are purely cosmetic, except for removal of `RkCanvas *canvas` member from `RkCairoGraphicsBackend` because it was unused, and changing return type for `ring_buffer_resize` to void. If the canvas member can theoretically be useful then instead of removal we can put `[[maybe_unused]]` attribute on it to silence the warning.