### PR TITLE
Fix UBSan errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,10 +41,10 @@ endif ()
 
 if (GKICK_ARCHITECTURE MATCHES x86_64)
   message(STATUS "set optimisation compiler flags for ${GKICK_ARCHITECTURE}")
-  set(GKICK_OPTIMISATION_FLAGS "-O3 -msse -msse2 -mfpmath=sse -ffast-math -fomit-frame-pointer")
+  set(GKICK_OPTIMISATION_FLAGS "-O3 -msse -msse2 -mfpmath=sse -funsafe-math-optimizations -fno-math-errno -fno-trapping-math -fomit-frame-pointer")
 else ()
   message(STATUS "set optimisation compiler flags for ${GKICK_ARCHITECTURE}")
-  set(GKICK_OPTIMISATION_FLAGS "-O3 -ffast-math -fomit-frame-pointer")
+  set(GKICK_OPTIMISATION_FLAGS "-O3 -funsafe-math-optimizations -fno-math-errno -fno-trapping-math -fomit-frame-pointer")
 endif ()
 
 set(CMAKE_CXX_STANDARD 17)

--- a/src/compressor_group_box.cpp
+++ b/src/compressor_group_box.cpp
@@ -156,7 +156,8 @@ void CompressorGroupBox::updateGui()
         compressorCheckbox->setPressed(geonkickApi->isCompressorEnabled());
 
         // Attack
-        attackSlider->onSetValue(100 * (log10(1000 * geonkickApi->getCompressorAttack()) / log10(2000)));
+        double attack = 100 * (log10(1000 * geonkickApi->getCompressorAttack()) / log10(2000));
+        attackSlider->onSetValue(static_cast<int>(std::max(attack, 0.0)));
 
         // Threshold
         auto threshold = geonkickApi->getCompressorThreshold();

--- a/src/dsp/src/geonkick.h
+++ b/src/dsp/src/geonkick.h
@@ -39,6 +39,10 @@ extern "C" {
 #include <float.h>
 #include <stdbool.h>
 
+#ifdef __FAST_MATH__
+#error -ffast-math disables nan detection needed by geonkick
+#endif
+
 #ifdef __STDC_NO_ATOMICS__
 #error atomic operations are not supported
 #endif

--- a/src/dsp/src/mixer.c
+++ b/src/dsp/src/mixer.c
@@ -109,8 +109,8 @@ gkick_mixer_process(struct gkick_mixer *mixer,
                                                           out[right_index] + offset,
                                                           size,
                                                           limiter_val);
-                                gkick_real leveler_val = ring_buffer_get_cur_data(output->ring_buffer);
-                                leveler_val *= limiter_val;
+                                gkick_real sample = ring_buffer_get_cur_data(output->ring_buffer);
+                                gkick_real leveler_val = fabsf(sample) * limiter_val;
                                 gkick_mixer_set_leveler(mixer, i, leveler_val);
                         }
                         ring_buffer_next(output->ring_buffer, size);

--- a/src/dsp/src/synthesizer.c
+++ b/src/dsp/src/synthesizer.c
@@ -1088,9 +1088,14 @@ synth_kick_env_get_apply_type(struct gkick_synth *synth,
 			      enum gkick_envelope_apply_type *apply_type)
 {
 	gkick_synth_lock(synth);
-        if (env_type == GEONKICK_FILTER_CUTOFF_ENVELOPE) {
+        switch (env_type) {
+        case GEONKICK_FILTER_CUTOFF_ENVELOPE:
 		*apply_type = gkick_envelope_get_apply_type(synth->filter->cutoff_env);
-	}
+                break;
+        default:
+                *apply_type = GEONKICK_ENVELOPE_APPLY_LINEAR;
+                break;
+        }
         gkick_synth_unlock(synth);
         return GEONKICK_OK;	
 }

--- a/src/kit_model.cpp
+++ b/src/kit_model.cpp
@@ -163,7 +163,8 @@ int KitModel::percussionLimiter(PercussionIndex index) const
 int KitModel::percussionLeveler(PercussionIndex index) const
 {
         auto realVal = geonkickApi->getLimiterLevelerValue(percussionId(index));
-        double logVal = 20 * log10(realVal);
+        // add small delta to avoid -inf for zero value
+        double logVal = 20 * log10(realVal + 0.000000001);
         int val = (logVal + 55.0) * 100.0 / 75;
         if (val < 0)
                 val = 0;


### PR DESCRIPTION
Since we now found three bugs in geonkick with the help of debug flags and llvm toolchain, i decided to build geonkick with clang and `-fsanitize=undefined` to see what else may come up. Here are the errors:
```
/home/me/geonkick/src/geonkick_api.cpp:714:40: runtime error: load of value 3183113248, which is not a valid value for type 'enum gkick_envelope_apply_type'
/home/me/geonkick/src/compressor_group_box.cpp:159:34: runtime error: -inf is outside the range of representable values of type 'int'
/home/me/geonkick/src/kit_model.cpp:167:19: runtime error: -inf is outside the range of representable values of type 'int'
/usr/include/rapidjson/internal/stack.h:117:13: runtime error: applying non-zero offset 16 to null pointer
/usr/include/rapidjson/internal/stack.h:117:13: runtime error: applying non-zero offset 1 to null pointer
```

Ignoring rapidjson issue(it is known and [fixed](https://github.com/Tencent/rapidjson/issues/1724) but not released yet), there are 3 errors:
- [synth_kick_env_get_apply_type](https://github.com/Geonkick-Synthesizer/geonkick/blob/1d20f0069c4bbd7213609a355a727af3172d9b20/src/dsp/src/synthesizer.c#L1086) was sometimes called with envelope type different from filter cutoff envelope, which resulted in uninitialized apply\_type [here](https://github.com/Geonkick-Synthesizer/geonkick/blob/1d20f0069c4bbd7213609a355a727af3172d9b20/src/geonkick_api.cpp#L710) and everywhere it was used. Fixed in this PR.
- an int argument [passed](https://github.com/Geonkick-Synthesizer/geonkick/blob/1d20f0069c4bbd7213609a355a727af3172d9b20/src/compressor_group_box.cpp#L159) to attackSlider->onSetValue was derived from log10(0), which is -inf. Fixed in this PR.
- and now the hard one which i could not easily fix: the leveler value used [here](https://github.com/Geonkick-Synthesizer/geonkick/blob/1d20f0069c4bbd7213609a355a727af3172d9b20/src/kit_model.cpp#L165) can sometimes be not just zero, but significantly below zero(-0.16,- 0.2 and similar values were observed in gdb), resulting in NaN when passed to log10. I found out that it comes from [here](https://github.com/Geonkick-Synthesizer/geonkick/blob/1d20f0069c4bbd7213609a355a727af3172d9b20/src/dsp/src/mixer.c#L114), and as i understand the leveler is set from current sample value multiplied by limiter, which does not make sense to me, because apparently it is supposed to be non-negative(it's passed to log10!), and i don't exactly know what leveler means in that context(in my understanding the leveler is something used per channel, not per sample). So, i'm leaving it up to you to figure out what's happening and what to do with that:)